### PR TITLE
Change callback arguments to (err, ms) and dont throw in async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var Ping = require('ping-lite');
 
 var ping = new Ping('8.8.8.8');
 
-ping.send(function(ms) {
+ping.send(function(err, ms) {
   console.log(this._host+' responded in '+ms+'ms.');
 });
 ```
@@ -41,7 +41,7 @@ var Ping = require('ping-lite');
 
 var ping = new Ping('8.8.8.8');
 
-ping.send(function(ms) {
+ping.send(function(err, ms) {
   console.log(this._host+' responded in '+ms+'ms.');
 });
 ```
@@ -51,7 +51,7 @@ var Ping = require('ping-lite');
 
 var ping = new Ping('8.8.8.8');
 
-ping.start(function(ms) {
+ping.start(function(err, ms) {
   console.log(this._host+' responded in '+ms+'ms.');
 });
 
@@ -69,7 +69,7 @@ ping.on('error', function(err) {
   console.log('uhoh: ',err);
 });
 
-ping.on('result', function(ms) {
+ping.on('result', function(err, ms) {
   console.log(this._host+' responded in '+ms+'ms.');
 });
 

--- a/ping-lite.js
+++ b/ping-lite.js
@@ -49,14 +49,15 @@ Ping.prototype.__proto__ = events.EventEmitter.prototype;
 // ===========
 Ping.prototype.send = function(callback) {
   var self = this;
+  callback = callback || function(err, ms) {
+    if (err) return self.emit('error', err);
+    else     return self.emit('result', ms);
+  }
 
   this._ping = spawn(this._bin, this._args); // spawn the binary
 
   this._ping.on('error', function(err) { // handle binary errors
-    if (callback)
-      callback(err);
-    else
-      self.emit('error', err);
+    callback(err);
   });
 
   this._ping.stdout.on('data', function(data) { // log stdout
@@ -73,17 +74,14 @@ Ping.prototype.send = function(callback) {
         ms;
 
     if (stderr)
-      throw new Error(stderr);
+      return callback(new Error(stderr));
     else if (!stdout)
-      throw new Error('No stdout detected');
+      return callback(new Error('No stdout detected'));
 
     ms = stdout.match(self._regmatch); // parse out the ##ms response
     ms = (ms && ms[1]) ? Number(ms[1]) : ms;
 
-    if (callback)
-      callback(ms);
-    else
-      self.emit('result', ms);
+    callback(null, ms);
   });
 };
 

--- a/test/mocha_test.js
+++ b/test/mocha_test.js
@@ -18,21 +18,21 @@ describe('ping-lite.js', function() {
     this.timeout(6000); // ping timer shouldn't exceed 5000ms
     it('8.8.8.8 should get a response', function(done) {
       var ping = new Ping('8.8.8.8');
-      ping.send(function(ms) {
+      ping.send(function(err, ms) {
         assert(Number(ms), 'Google DNS may not be reachable');
         done();
       });
     });
     it('www.google.com should get a response', function(done) {
       var ping = new Ping('www.google.com');
-      ping.send(function(ms) {
+      ping.send(function(err, ms) {
         assert(Number(ms), 'Google may not be reachable');
         done();
       });
     });
     it('8.8.8.88 should NOT get a response', function(done) {
       var ping = new Ping('8.8.8.88');
-      ping.send(function(ms) {
+      ping.send(function(err, ms) {
         assert(ms === null, 'how did you ping 8.8.8.88!?');
         done();
       });
@@ -43,7 +43,7 @@ describe('ping-lite.js', function() {
       this.timeout(16000);
       var ping = new Ping('8.8.8.8');
       var pings = 0;
-      ping.start(function(ms) {
+      ping.start(function(err, ms) {
         assert((Number(ms) || ms === null), '#send returned something unexpected');
         ++pings;
       });
@@ -57,7 +57,7 @@ describe('ping-lite.js', function() {
       this.timeout(5100);
       var ping = new Ping('8.8.8.8', { interval: 500 });
       var pings = 0;
-      ping.start(function(ms) {
+      ping.start(function(err, ms) {
         assert((Number(ms) || ms === null), '#send returned something unexpected');
         if (++pings === 10)
           done();


### PR DESCRIPTION
This changes the callbacks to `callback(err, ms)` instead of `callback(ms)`.
Instead of throwing the error, it is now passed in to the callback. Throwing in an async functions will always be uncaught.

This is a breaking change.