### PR TITLE
Fix regex match for sub 1ms response times on Windows. This happens o…

### DIFF
--- a/ping-lite.js
+++ b/ping-lite.js
@@ -19,7 +19,7 @@ function Ping(host, options) {
   if (WIN) {
     this._bin = 'c:/windows/system32/ping.exe';
     this._args = (options.args) ? options.args : [ '-n', '1', '-w', '5000', host ];
-    this._regmatch = /time=(.+?)ms/;
+    this._regmatch = /time[><=](.+?)ms/;
   }
   else if (LIN) {
     this._bin = '/bin/ping';


### PR DESCRIPTION
…n localhost pings, or possibly on pings to machines on local network.