### PR TITLE
add support for FreeBSD

### DIFF
--- a/ping-lite.js
+++ b/ping-lite.js
@@ -3,7 +3,8 @@ var spawn = require('child_process').spawn,
     fs = require('fs'),
     WIN = /^win/.test(process.platform),
     LIN = /^linux/.test(process.platform),
-    MAC = /^darwin/.test(process.platform);
+    MAC = /^darwin/.test(process.platform),
+    BSD = /^freebsd/.test(process.platform);
 
 module.exports = Ping;
 
@@ -27,6 +28,11 @@ function Ping(host, options) {
     this._regmatch = /=([0-9.]+?) ms/; // need to verify this
   }
   else if (MAC) {
+    this._bin = '/sbin/ping';
+    this._args = (options.args) ? options.args : [ '-n', '-t', '2', '-c', '1', host ];
+    this._regmatch = /=([0-9.]+?) ms/;
+  }
+  else if (BSD) {
     this._bin = '/sbin/ping';
     this._args = (options.args) ? options.args : [ '-n', '-t', '2', '-c', '1', host ];
     this._regmatch = /=([0-9.]+?) ms/;


### PR DESCRIPTION
This adds support for FreeBSD. Command syntax and flags are identical to MacOS, so it's about the simplest change possible. (No surprise since MacOS was based on BSD and the man pages still say "BSD System Manager's Manual" at the top.) 

It's running happily on FreeBSD 12.2-RELEASE and considering that ping hasn't changed in ages, it should have no problems on other versions.

Thanks for your consideration.